### PR TITLE
replaced TestGame entries with gameLoop() at new game and continue event

### DIFF
--- a/game.py
+++ b/game.py
@@ -408,7 +408,7 @@ class BallAndBrick:
                             quit()
 
                         elif event.key == pygame.K_n:
-                            TestGame().run()
+                            gameLoop()
 
         def settings():
             screen = pygame.display.get_surface()
@@ -454,7 +454,7 @@ class BallAndBrick:
                         quit()
                     if event.type == pygame.KEYDOWN:
                         if event.key == pygame.K_p:
-                            TestGame().run()
+                            gameLoop()
                         elif event.key == pygame.K_q:
                             pygame.quit()
                             quit()

--- a/game.py
+++ b/game.py
@@ -423,7 +423,7 @@ class BallAndBrick:
             y_max_ball = (screen.get_height() - 10) - b_diameter
             screen.fill(self.yellow)
             message_to_screen("Settings", self.black, -400, size="large")
-            message_to_screen("Press P to continue", self.black, -300, size="medium")
+            message_to_screen("Press N to start a new game", self.black, -300, size="medium")
             message_to_screen("Press Q to quit", self.black, -230, size="medium")
             message_to_screen("Themes: ", self.black, -150, size="medium")
             message_to_screen("1. Classic ", self.black, -80, size="small")
@@ -453,7 +453,7 @@ class BallAndBrick:
                         pygame.quit()
                         quit()
                     if event.type == pygame.KEYDOWN:
-                        if event.key == pygame.K_p:
+                        if event.key == pygame.K_n:
                             gameLoop()
                         elif event.key == pygame.K_q:
                             pygame.quit()


### PR DESCRIPTION
In the event of calling a new game from the pause screen by pressing `N` and when calling to continue from settings by pressing `P` the code had a line :
```TestGame().run()```

where TestGame does not exist and perhaps was a placeholder meant to stay during the dev phase only.
I have replaced it with `gameLoop()` which starts a new game

when calling new game it makes sense to start a new game
and when calling from settings to continue, we know that a game is not being continued so starting a new game works.

The following was the error displayed in the console.

``` 
Traceback (most recent call last):
   File "/home/user/git/ballbrick/game.py", line 584, in run
     gameLoop()
   File "/home/user/git/ballbrick/game.py", line 494, in gameLoop
     paused()
   File "/home/user/git/ballbrick/game.py", line 411, in paused
     TestGame().run()
NameError: name 'TestGame' is not defined 
```
 