### PR TITLE
Fix activity opens to a black canvas and key errors

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -34,7 +34,9 @@ class BallAndBrickActivity(sugar3.activity.activity.Activity):
         # Build the Pygame canvas.
 
         self._pygamecanvas = sugargame.canvas.PygameCanvas(
-            self, main=self.game.run, modules=[pygame.display]
+            self, main=self.game.run, modules=[pygame.display,
+                                               pygame.mixer,
+                                               pygame.font]
         )
 
         # Note that set_canvas implicitly calls read_file when

--- a/game.py
+++ b/game.py
@@ -204,8 +204,16 @@ class BallAndBrick:
             while Gtk.events_pending():
                 Gtk.main_iteration()
 
-            for event in self.py_events:
-                if event.type == pygame.KEYDOWN:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    quit()
+
+                elif event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_p:
+                        self.pause = True
+                        pause = True
+                        paused()
                     if event.key == pygame.K_LEFT:
                         self.keys_pressed[pygame.K_LEFT] = True
                     if event.key == pygame.K_RIGHT:
@@ -512,17 +520,6 @@ class BallAndBrick:
                 pygame.K_RIGHT: False
             }
             while 1:
-                self.py_events = pygame.event.get()
-                for event in self.py_events:
-                    if event.type == pygame.QUIT:
-                        pygame.quit()
-                        quit()
-                    if event.type == pygame.KEYDOWN:
-                        if event.key == pygame.K_p:
-                            self.pause = True
-                            pause = True
-                            paused()
-
                 self.clock.tick(50)
                 screen.fill(self.back_col)
                 check_input()

--- a/game.py
+++ b/game.py
@@ -92,11 +92,6 @@ class BallAndBrick:
             (212, 219, 178),
         )
 
-        pygame.mixer.init()
-        self.brick_hit_sound  = pygame.mixer.Sound("assets/brickhit.ogg")
-        self.paddle_hit_sound = pygame.mixer.Sound("assets/paddlehit.ogg")
-        self.brick_hit_sound.set_volume(0.8)
-
     # Called to save the state of the game to the Journal.
     def write_file(self, file_path):
         pass
@@ -106,6 +101,10 @@ class BallAndBrick:
         pass
 
     def run(self):
+        self.brick_hit_sound  = pygame.mixer.Sound("assets/brickhit.ogg")
+        self.paddle_hit_sound = pygame.mixer.Sound("assets/paddlehit.ogg")
+        self.brick_hit_sound.set_volume(0.8)
+        
         def restart_game():
             pygame.mixer.music.load("assets/jazz.ogg")
             pygame.mixer.music.play(-1)

--- a/game.py
+++ b/game.py
@@ -204,35 +204,47 @@ class BallAndBrick:
             y_max_ball = (screen.get_height() - 10) - b_diameter
             while Gtk.events_pending():
                 Gtk.main_iteration()
-            keys = pygame.key.get_pressed()
 
-            if keys[pygame.K_LEFT]:
+            for event in self.py_events:
+                if event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_LEFT:
+                        self.keys_pressed[pygame.K_LEFT] = True
+                    if event.key == pygame.K_RIGHT:
+                        self.keys_pressed[pygame.K_RIGHT] = True
+
+                    if event.key == pygame.K_c and self.state == self.ball_still:
+                        if self.score > 150:
+                            self.ball_vel = pygame.Vector2(10, -10)
+                        elif self.score > 100:
+                            self.ball_vel = pygame.Vector2(8, -8)
+                        else:
+                            self.ball_vel = pygame.Vector2(7, -7)
+                        self.state = self.ball_play
+                    elif event.key == pygame.K_n and (
+                        self.state == self.ball_game_over or self.state == self.ball_won
+                    ):
+                        restart_game()
+                    elif event.key == pygame.K_s:
+                        settings()
+                    elif event.key == pygame.K_q:
+                        pygame.quit()
+                        quit()
+
+                elif event.type == pygame.KEYUP:
+                    if event.key == pygame.K_LEFT:
+                        self.keys_pressed[pygame.K_LEFT] = False
+                    if event.key == pygame.K_RIGHT:
+                        self.keys_pressed[pygame.K_RIGHT] = False
+
+            if self.keys_pressed[pygame.K_LEFT]:
                 self.paddle.left -= 12
                 if self.paddle.left < 0:
                     self.paddle.left = 0
 
-            if keys[pygame.K_RIGHT]:
+            if self.keys_pressed[pygame.K_RIGHT]:
                 self.paddle.left += 12
                 if self.paddle.left > x_max_scrol:
                     self.paddle.left = x_max_scrol
-
-            if keys[pygame.K_c] and self.state == self.ball_still:
-                if self.score > 150:
-                    self.ball_vel = pygame.Vector2(10, -10)
-                elif self.score > 100:
-                    self.ball_vel = pygame.Vector2(8, -8)
-                else:
-                    self.ball_vel = pygame.Vector2(7, -7)
-                self.state = self.ball_play
-            elif keys[pygame.K_n] and (
-                self.state == self.ball_game_over or self.state == self.ball_won
-            ):
-                restart_game()
-            elif keys[pygame.K_s]:
-                settings()
-            elif keys[pygame.K_q]:
-                pygame.quit()
-                quit()
 
         def move_ball():
             screen = pygame.display.get_surface()
@@ -496,8 +508,13 @@ class BallAndBrick:
 
             pygame.display.update()
             restart_game()
+            self.keys_pressed = {
+                pygame.K_LEFT: False,
+                pygame.K_RIGHT: False
+            }
             while 1:
-                for event in pygame.event.get():
+                self.py_events = pygame.event.get()
+                for event in self.py_events:
                     if event.type == pygame.QUIT:
                         pygame.quit()
                         quit()

--- a/game.py
+++ b/game.py
@@ -91,6 +91,8 @@ class BallAndBrick:
             (255, 255, 49),
             (212, 219, 178),
         )
+
+        pygame.mixer.init()
         self.brick_hit_sound  = pygame.mixer.Sound("assets/brickhit.ogg")
         self.paddle_hit_sound = pygame.mixer.Sound("assets/paddlehit.ogg")
         self.brick_hit_sound.set_volume(0.8)
@@ -382,7 +384,7 @@ class BallAndBrick:
             pygame.mixer.music.unpause()
             self.pause = False
 
-        def paused():
+        def draw_pause():
             screen = pygame.display.get_surface()
             screen.fill(self.back_col)
             message_to_screen("Paused", self.brick_col, 0, size="large")
@@ -391,9 +393,11 @@ class BallAndBrick:
                 "Press N for a new game", self.brick_col, 170, size="medium"
             )
             message_to_screen("Press Q to quit", self.brick_col, 240, size="medium")
-            pygame.mixer.music.pause()
             pygame.display.update()
 
+        def paused():
+            draw_pause()
+            pygame.mixer.music.pause()
             self.pause = True
             while self.pause:
                 while Gtk.events_pending():
@@ -401,6 +405,7 @@ class BallAndBrick:
                 for event in pygame.event.get():
                     if event.type == pygame.VIDEORESIZE:
                         pygame.display.set_mode(event.size, pygame.RESIZABLE)
+                        draw_pause()
 
                     if event.type == pygame.QUIT:
                         pygame.quit()
@@ -415,7 +420,7 @@ class BallAndBrick:
                         elif event.key == pygame.K_n:
                             gameLoop()
 
-        def settings():
+        def draw_settings():
             screen = pygame.display.get_surface()
             brick_w = round((screen.get_width()) / 10.7)
             brick_h = round((screen.get_height()) / 32)
@@ -447,12 +452,16 @@ class BallAndBrick:
                 size="medium",
             )
             pygame.display.update()
+
+        def settings():
+            draw_settings()
             while True:
                 while Gtk.events_pending():
                     Gtk.main_iteration()
                 for event in pygame.event.get():
                     if event.type == pygame.VIDEORESIZE:
                         pygame.display.set_mode(event.size, pygame.RESIZABLE)
+                        draw_settings()
 
                     if event.type == pygame.QUIT:
                         pygame.quit()
@@ -580,6 +589,7 @@ class BallAndBrick:
             for event in pygame.event.get():
                 if event.type == pygame.VIDEORESIZE:
                     pygame.display.set_mode(event.size, pygame.RESIZABLE)
+                    draw_welcome()
 
                 if event.type == pygame.QUIT:
                     pygame.quit()

--- a/sugargame/__init__.py
+++ b/sugargame/__init__.py
@@ -1,1 +1,23 @@
+#
+# Copyright (c) 2020 Wade Brainerd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 __version__ = '1.3'

--- a/sugargame/canvas.py
+++ b/sugargame/canvas.py
@@ -1,3 +1,25 @@
+#
+# Copyright (c) 2020 Wade Brainerd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 import os
 from gi.repository import Gtk
 from gi.repository import GLib

--- a/sugargame/event.py
+++ b/sugargame/event.py
@@ -1,3 +1,25 @@
+#
+# Copyright (c) 2020 Wade Brainerd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 import logging
 from gi.repository import GLib
 from gi.repository import Gdk
@@ -42,6 +64,143 @@ class Translator(object):
         pygame.K_RSHIFT: pygame.KMOD_RSHIFT,
     }
 
+    keys = [
+        pygame.K_UNKNOWN,
+        pygame.K_BACKSPACE,
+        pygame.K_TAB,
+        pygame.K_RETURN,
+        pygame.K_ESCAPE,
+        pygame.K_SPACE,
+        pygame.K_EXCLAIM,
+        pygame.K_QUOTEDBL,
+        pygame.K_HASH,
+        pygame.K_DOLLAR,
+        pygame.K_PERCENT,
+        pygame.K_AMPERSAND,
+        pygame.K_QUOTE,
+        pygame.K_LEFTPAREN,
+        pygame.K_RIGHTPAREN,
+        pygame.K_ASTERISK,
+        pygame.K_PLUS,
+        pygame.K_COMMA,
+        pygame.K_MINUS,
+        pygame.K_PERIOD,
+        pygame.K_SLASH,
+        pygame.K_0,
+        pygame.K_1,
+        pygame.K_2,
+        pygame.K_3,
+        pygame.K_4,
+        pygame.K_5,
+        pygame.K_6,
+        pygame.K_7,
+        pygame.K_8,
+        pygame.K_9,
+        pygame.K_COLON,
+        pygame.K_SEMICOLON,
+        pygame.K_LESS,
+        pygame.K_EQUALS,
+        pygame.K_GREATER,
+        pygame.K_QUESTION,
+        pygame.K_AT,
+        pygame.K_LEFTBRACKET,
+        pygame.K_BACKSLASH,
+        pygame.K_RIGHTBRACKET,
+        pygame.K_CARET,
+        pygame.K_UNDERSCORE,
+        pygame.K_BACKQUOTE,
+        pygame.K_a,
+        pygame.K_b,
+        pygame.K_c,
+        pygame.K_d,
+        pygame.K_e,
+        pygame.K_f,
+        pygame.K_g,
+        pygame.K_h,
+        pygame.K_i,
+        pygame.K_j,
+        pygame.K_k,
+        pygame.K_l,
+        pygame.K_m,
+        pygame.K_n,
+        pygame.K_o,
+        pygame.K_p,
+        pygame.K_q,
+        pygame.K_r,
+        pygame.K_s,
+        pygame.K_t,
+        pygame.K_u,
+        pygame.K_v,
+        pygame.K_w,
+        pygame.K_x,
+        pygame.K_y,
+        pygame.K_z,
+        pygame.K_DELETE,
+        pygame.K_CAPSLOCK,
+        pygame.K_F1,
+        pygame.K_F2,
+        pygame.K_F3,
+        pygame.K_F4,
+        pygame.K_F5,
+        pygame.K_F6,
+        pygame.K_F7,
+        pygame.K_F8,
+        pygame.K_F9,
+        pygame.K_F10,
+        pygame.K_F11,
+        pygame.K_F12,
+        pygame.K_PRINT,
+        pygame.K_SCROLLOCK,
+        pygame.K_BREAK,
+        pygame.K_INSERT,
+        pygame.K_HOME,
+        pygame.K_PAGEUP,
+        pygame.K_END,
+        pygame.K_PAGEDOWN,
+        pygame.K_RIGHT,
+        pygame.K_LEFT,
+        pygame.K_DOWN,
+        pygame.K_UP,
+        pygame.K_NUMLOCK,
+        pygame.K_KP_DIVIDE,
+        pygame.K_KP_MULTIPLY,
+        pygame.K_KP_MINUS,
+        pygame.K_KP_PLUS,
+        pygame.K_KP_ENTER,
+        pygame.K_KP1,
+        pygame.K_KP2,
+        pygame.K_KP3,
+        pygame.K_KP4,
+        pygame.K_KP5,
+        pygame.K_KP6,
+        pygame.K_KP7,
+        pygame.K_KP8,
+        pygame.K_KP9,
+        pygame.K_KP0,
+        pygame.K_KP_PERIOD,
+        pygame.K_POWER,
+        pygame.K_KP_EQUALS,
+        pygame.K_F13,
+        pygame.K_F14,
+        pygame.K_F15,
+        pygame.K_HELP,
+        pygame.K_MENU,
+        pygame.K_SYSREQ,
+        pygame.K_CLEAR,
+        pygame.K_CURRENCYUNIT,
+        pygame.K_CURRENCYSUBUNIT,
+        pygame.K_LCTRL,
+        pygame.K_LSHIFT,
+        pygame.K_LALT,
+        pygame.K_LMETA,
+        pygame.K_RCTRL,
+        pygame.K_RSHIFT,
+        pygame.K_RALT,
+        pygame.K_RMETA,
+        pygame.K_MODE,
+        pygame.K_AC_BACK
+    ]
+
     def __init__(self, activity, inner_evb):
         """Initialise the Translator with the windows to which to listen"""
         self._activity = activity
@@ -68,17 +227,16 @@ class Translator(object):
 
         # Callback functions to link the event systems
         self._activity.connect('unrealize', self._quit_cb)
-        self._activity.connect('visibility_notify_event', self._visibility_cb)
+        self._activity.connect('visibility-notify-event', self._visibility_cb)
         self._activity.connect('configure-event', self._resize_cb)
-        self._inner_evb.connect('key_press_event', self._keydown_cb)
-        self._inner_evb.connect('key_release_event', self._keyup_cb)
-        self._inner_evb.connect('button_press_event', self._mousedown_cb)
-        self._inner_evb.connect('button_release_event', self._mouseup_cb)
+        self._inner_evb.connect('key-press-event', self._keydown_cb)
+        self._inner_evb.connect('key-release-event', self._keyup_cb)
+        self._inner_evb.connect('button-press-event', self._mousedown_cb)
+        self._inner_evb.connect('button-release-event', self._mouseup_cb)
         self._inner_evb.connect('motion-notify-event', self._mousemove_cb)
         self._inner_evb.connect('screen-changed', self._screen_changed_cb)
 
         # Internal data
-        self.__keystate = [0] * 323
         self.__button_state = [0, 0, 0]
         self.__mouse_pos = (0, 0)
         self.__repeat = (None, None)
@@ -86,6 +244,7 @@ class Translator(object):
         self.__held_time_left = {}
         self.__held_last_time = {}
         self.__tick_id = None
+        self.__keystate = dict((i, False) for i in self.keys)
 
     def hook_pygame(self):
         pygame.key.get_pressed = self._get_pressed
@@ -179,7 +338,7 @@ class Translator(object):
         return True
 
     def _get_pressed(self):
-        return self.__keystate
+        return list(self.__keystate.values())
 
     def _get_mouse_pressed(self):
         return self.__button_state


### PR DESCRIPTION
VIDEORESIZE event is triggered on activity startup, which is handled by calling pygame.display.set_mode(). This returns an empty Surface object completely discarding the previous state of screen.

* Call draw functions after resizing to populate the newly returned empty surface with game elements,

* Initialize pygame mixer.

Fixes #21 , and the potential issues encountered in #22 (of not being able to resize the window) 
@chimosky, @quozl, @walterbender please review.